### PR TITLE
make message detail a proper detail view

### DIFF
--- a/student-info-system/schooladmin/views/users.py
+++ b/student-info-system/schooladmin/views/users.py
@@ -92,6 +92,7 @@ def user(request, userid):
                 request=request,
                 wrap_list=False,
                 self_url=reverse('schooladmin:user', args=[userid]),
+                click_url=reverse('sis:viewmessage', args=[DUMMY_ID]),
             ))
         data.update(
             filtered_table2(
@@ -102,6 +103,7 @@ def user(request, userid):
                 request=request,
                 wrap_list=False,
                 self_url=reverse('schooladmin:user', args=[userid]),
+                click_url=reverse('sis:viewmessage', args=[DUMMY_ID]),
             ))
 
     return render(request, 'schooladmin/user.html', data)
@@ -341,6 +343,7 @@ def student(request, userid):
                 request=request,
                 wrap_list=False,
                 self_url=reverse('schooladmin:student', args=[userid]),
+                click_url=reverse('sis:viewmessage', args=[DUMMY_ID]),
             ))
         data.update(
             filtered_table2(
@@ -351,6 +354,7 @@ def student(request, userid):
                 request=request,
                 wrap_list=False,
                 self_url=reverse('schooladmin:student', args=[userid]),
+                click_url=reverse('sis:viewmessage', args=[DUMMY_ID]),
             ))
 
     return render(request, 'schooladmin/student.html', data)
@@ -422,6 +426,7 @@ def professor(request, userid):
                 request=request,
                 wrap_list=False,
                 self_url=reverse('schooladmin:professor', args=[userid]),
+                click_url=reverse('sis:viewmessage', args=[DUMMY_ID]),
             ))
         data.update(
             filtered_table2(
@@ -432,6 +437,7 @@ def professor(request, userid):
                 request=request,
                 wrap_list=False,
                 self_url=reverse('schooladmin:professor', args=[userid]),
+                click_url=reverse('sis:viewmessage', args=[DUMMY_ID]),
             ))
 
     if not logged_in:

--- a/student-info-system/sis/elements/__init__.py
+++ b/student-info-system/sis/elements/__init__.py
@@ -1,4 +1,5 @@
 import django_tables2 as tables
+import types
 
 
 # Each column and cell has its own CSS class based on the type of
@@ -10,16 +11,11 @@ def field_css_classes(field_name):
 # mix in a method to get specified CSS row class. Used by filtered_table2
 def row_class(cls):
     ra = getattr(cls, 'Meta').row_attrs
-    return ra['class']
-
-
-tables.Table.row_class = classmethod(row_class)
-
-
-# mix in a method to get specified CSS row class. Used by filtered_table2
-def row_class(cls):
-    ra = getattr(cls, 'Meta').row_attrs
-    return ra['class']
+    rowc = ra['class']
+    # for message tables, there are record-dependent classes
+    if isinstance(rowc, types.LambdaType):
+        rowc = rowc(None)
+    return rowc
 
 
 tables.Table.row_class = classmethod(row_class)

--- a/student-info-system/sis/elements/message.py
+++ b/student-info-system/sis/elements/message.py
@@ -232,14 +232,15 @@ class MessageDetailForm(forms.ModelForm):
         fields = ('role', 'bio')
 
 
-def classes_for(record):
-    cl = 'message_row'
-    if record.unread:
-        cl += ' unread'
-    if record.time_archived is not None:
-        cl += ' archived'
-    if record.aged_request():
-        cl += ' aged-request'
+def classes_for(record=None, row_class="message_row"):
+    cl = row_class
+    if record is not None:
+        if record.unread:
+            cl += ' unread'
+        if record.time_archived is not None:
+            cl += ' archived'
+        if record.aged_request():
+            cl += ' aged-request'
 
     return cl
 
@@ -295,7 +296,7 @@ class MessageTable(tables.Table):
         fields = ('unread', 'high_priority', 'time_sent', 'recipient', 'sender', 'subject',
                   'handled')
         row_attrs = {
-            'class': (lambda record: 'message_row unread' if record.unread else 'message_row'),
+            'class': (lambda record: classes_for(record)),
             'data-id': lambda record: record.pk
         }
         attrs = {"class": 'message_table'}
@@ -306,7 +307,7 @@ class MessageReceivedTable(MessageTable):
     class Meta:
         exclude = ('recipient', 'time_read')
         row_attrs = {
-            'class': (lambda record: classes_for(record)),
+            'class': (lambda record: classes_for(record, 'received-row')),
             'data-id': lambda record: record.pk
         }
         attrs = {"class": 'message_table'}
@@ -317,7 +318,7 @@ class StudentMessageReceivedTable(MessageReceivedTable):
     class Meta:
         exclude = ('handled',)
         row_attrs = {
-            'class': (lambda record: classes_for(record)),
+            'class': (lambda record: classes_for(record, 'received-row')),
             'data-id': lambda record: record.pk
         }
         attrs = {"class": 'message_table'}
@@ -332,7 +333,7 @@ class MessageSentTable(MessageTable):
             'handled',
         )
         row_attrs = {
-            'class': (lambda record: classes_for(record)),
+            'class': (lambda record: classes_for(record, 'sent-row')),
             'data-id': lambda record: record.pk
         }
         attrs = {"class": 'message_table'}

--- a/student-info-system/sis/templates/sis/message.html
+++ b/student-info-system/sis/templates/sis/message.html
@@ -1,10 +1,17 @@
-{% extends 'sis/base.html' %}
+{% extends user.home_template %}
 {% load static %}
 {% load bootstrap3 %}
-{% block class %}messages{% endblock %}
+{% load render_table from django_tables2 %}
+{% load sis-filter %}
 
-{% block all_content %}
-    <div><span class="message_header">From:</span>
+{% block class %}{{ block_class }}{% endblock %}
+
+{% block content %}
+<span>
+    {% if prev %} <input id="prev" action="action" class="btn btn-info" value="Previous"/> {% endif %}
+    {% if next %} <input id="next" action="action" class="btn btn-info" value="Next"/> {% endif %}
+</span>
+   <div><span class="message_header">From:</span>
         <span class="message_header_value">{{ message.sender.user.get_full_name }}</span></div>
     <div><span class="message_header">To:</span>
         <span class="message_header_value">{{ message.recipient.user.get_full_name }}</span></div>
@@ -80,15 +87,9 @@
 {% endblock %}
 
 {% block late_scripts %}
-    <script>
-document.getElementById("archive").addEventListener("click", function () {
-        this.form.submit();
-        return true;
-    });
-document.getElementById("unarchive").addEventListener("click", function () {
-        this.form.submit();
-        return true;
-    });
-
-    </script>
+<script>
+{% if prev %} addButtonClickHandler('prev', "{% url detail_class prev %}"); {% endif %}
+{% if next %} addButtonClickHandler('next', "{% url detail_class next %}"); {% endif %}
+</script>
 {% endblock %}
+

--- a/student-info-system/sis/templates/sis/messages.html
+++ b/student-info-system/sis/templates/sis/messages.html
@@ -8,58 +8,13 @@
 
 {% block content %}
         <h3>Received Messages:</h3>
-    <div id="received">
-        {% if received_filter %}
-            <form id="received_filter" action="" method="get" class="form form-inline" autocomplete="off">
-                {% bootstrap_form received_filter.form layout='inline' %}
-                <button class="btn btn-primary">Filter</button>
-                {% if received_has_filter %}
-                    <a  class="btn btn-success" href="{%  url 'sis:messages' %}">Clear</a>
-                {% endif %}
-            </form>
-        {% endif %}
-        <div class="data-table-alt">
-            {% render_table received_table 'django_tables2/bootstrap.html' %}
-        </div>
-    </div>
-
-    <div id="received-detail-div" class="message_detail_div">
-    <iframe id="received_frame" class="message_detail_iframe" title="Message Detail" ></iframe>
-    </div>
+        {% sis_filter 'received' %}
 
         <h3>Sent Messages:</h3>
-    <div id="sent">
-        {% if sent_filter %}
-            <form id="sent_filter" action="" method="get" class="form form-inline" autocomplete="off">
-                {% bootstrap_form sent_filter.form layout='inline' %}
-                <button class="btn btn-primary">Filter</button>
-                {% if sent_has_filter %}
-                    <a  class="btn btn-success" href="{%  url 'sis:messages' %}">Clear</a>
-                {% endif %}
-            </form>
-        {% endif %}
-        <div class="data-table-alt">
-            {% render_table sent_table 'django_tables2/bootstrap.html' %}
-        </div>
-    </div>
-
-     <div id="sent-detail-div" class="message_detail_div">
-    <iframe id="sent_frame" class="message_detail_iframe" title="Message Detail" ></iframe>
-    </div>
+        {% sis_filter 'sent' %}
 
 <script>
-addDetailClickHander({template:"{% url 'sis:message' id=1234599 %}",
-    table_parent: 'received',
-    row_class:"message_row",
-    iframe_id:'received_frame',
-    mark_read: true
-});
-addDetailClickHander({template:"{% url 'sis:message' id=1234599 %}",
-    table_parent: 'sent',
-    row_class:"message_row",
-    iframe_id:'sent_frame',
-    mark_read: false
-});
 stylizeRange({field:'time_sent',name:'Sent',prefix:'received',width:'100px'});
+stylizeRange({field:'time_sent',name:'Sent',prefix:'sent',width:'100px'});
 </script>
 {% endblock %}

--- a/student-info-system/sis/urls.py
+++ b/student-info-system/sis/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('majors', majors.majors, name='majors'),
     path('major/<int:majorid>', majors.major, name='major'),
     path('messages', messages.usermessages, name='messages'),
+    path('viewmessage/<int:id>', messages.viewmessage, name='viewmessage'),
     path('message/<int:id>', messages.message, name='message'),
     path('user/<int:userid>/change_password', users.user_change_password, name='change_password'),
     path('secitem/<int:id>', sectionreferenceitem.sectionreferenceitem, name='secitem'),

--- a/student-info-system/sis/utils.py
+++ b/student-info-system/sis/utils.py
@@ -78,16 +78,21 @@ def filtered_table2(name=None,
 
 
 def next_prev(request, name, key, fallback=None):
-    pk_list = request.session.get(name + '-pks', None)
-    if pk_list is None and fallback:
-        pk_list = request.session.get(fallback + '-pks', None)
+
+    def try_to_find(aName):
+        pk_list = request.session.get(aName + '-pks', None)
+        if pk_list:
+            as_list = [int(x) for x in pk_list.split(',')]
+            if key in as_list:
+                loc = as_list.index(key)
+                if loc > 0:
+                    data['prev'] = as_list[loc - 1]
+                if loc < len(as_list) - 1:
+                    data['next'] = as_list[loc + 1]
+
     data = {}
-    if pk_list:
-        as_list = [int(x) for x in pk_list.split(',')]
-        if key in as_list:
-            loc = as_list.index(key)
-            if loc > 0:
-                data['prev'] = as_list[loc - 1]
-            if loc < len(as_list) - 1:
-                data['next'] = as_list[loc + 1]
+    try_to_find(name)
+    # check second list if there is one, and if we couldn't find id in first list
+    if len(data) == 0 and fallback:
+        try_to_find(fallback)
     return data

--- a/student-info-system/sis/views/messages.py
+++ b/student-info-system/sis/views/messages.py
@@ -3,10 +3,11 @@ import pytz
 from django.contrib import messages
 from django.shortcuts import redirect, render
 from django.contrib.auth.decorators import login_required
+from django.urls import reverse
 
 from sis.models import (Profile, Major, Message, SectionStudent, Student)
 
-from sis.utils import filtered_table, filtered_table2, DUMMY_ID
+from sis.utils import filtered_table, filtered_table2, DUMMY_ID, next_prev
 
 from sis.elements.message import (FullSentMessageFilter, FullReceivedMessageFilter,
                                   SentMessageFilter, ReceivedMessageFilter, MessageSentTable,
@@ -31,29 +32,38 @@ def usermessages(request):
         'auser': the_user,
     }
     data.update(
-        filtered_table(
+        filtered_table2(
             name='received',
             qs=the_user.profile.sent_to.all(),
             filter=receivedFilter,
             table=receivedTable,
             request=request,
-            wrap_list=False,
+            scrollable=True,
+            self_url=reverse('sis:messages'),
+            click_url=reverse('sis:message', args=[DUMMY_ID]),
         ))
     data.update(
-        filtered_table(
+        filtered_table2(
             name='sent',
             qs=the_user.profile.sent_by.all(),
             filter=sentFilter,
             table=MessageSentTable,
             request=request,
-            wrap_list=False,
+            scrollable=True,
+            self_url=reverse('sis:messages'),
+            click_url=reverse('sis:message', args=[DUMMY_ID]),
         ))
 
     return render(request, 'sis/messages.html', data)
 
 
 @login_required
-def message(request, id):
+def viewmessage(request, id):
+    return message(request, id, read_only=True)
+
+
+@login_required
+def message(request, id, read_only=False):
     the_user = request.user
     the_profile = the_user.profile
 
@@ -71,66 +81,74 @@ def message(request, id):
     if not (is_sender or is_recipient) and not is_admin:
         messages.error(request, 'Invalid message')
 
-    if request.method == 'POST':
-        if request.POST.get('unarchive', None) is not None:
-            messages.success(request, 'Message unarchived.')
-            the_mess.time_archived = None
+    if not read_only:
+        # mark our received messages read. Don't touch sent messages.
+        if is_recipient and the_mess.time_read is None:
+            the_mess.time_read = datetime.now(pytz.utc)
             the_mess.save()
 
-        elif request.POST.get('archive', None) is not None:
-            messages.success(request, 'Message archived.')
-            the_mess.time_archived = datetime.now(pytz.utc)
-            the_mess.save()
+        if request.method == 'POST':
+            if request.POST.get('unarchive', None) is not None:
+                messages.success(request, 'Message unarchived.')
+                the_mess.time_archived = None
+                the_mess.save()
+                return redirect('sis:messages')
 
-        elif request.POST.get('reply', None) is not None:
-            messages.success(request, 'Trust me, you replied.')
+            elif request.POST.get('archive', None) is not None:
+                messages.success(request, 'Message archived.')
+                the_mess.time_archived = datetime.now(pytz.utc)
+                the_mess.save()
+                return redirect('sis:messages')
 
-        elif is_admin and request.POST.get('approvedrop', None) is not None:
-            the_student = Student.objects.get(id=the_mess.support_data['student'])
-            the_ssect = SectionStudent.objects.get(id=the_mess.support_data['section'])
-            the_student.drop_approved(sectionstudent=the_ssect, request_message=the_mess)
-            messages.success(request, 'Drop Approved.')
+            elif request.POST.get('reply', None) is not None:
+                messages.success(request, 'Trust me, you replied.')
+                return redirect('sis:messages')
 
-        elif is_admin and request.POST.get('rejectdrop', None) is not None:
-            the_mess.time_handled = datetime.now(pytz.utc)
-            the_mess.save()
-            messages.success(request, 'Trust me, you rejected the drop.')
+            elif is_admin and request.POST.get('approvedrop', None) is not None:
+                the_student = Student.objects.get(id=the_mess.support_data['student'])
+                the_ssect = SectionStudent.objects.get(id=the_mess.support_data['section'])
+                the_student.drop_approved(sectionstudent=the_ssect, request_message=the_mess)
+                messages.success(request, 'Drop Approved.')
+                return redirect('sis:messages')
 
-        elif is_admin and request.POST.get('approvemajor', None) is not None:
-            the_student = Student.objects.get(id=the_mess.support_data['student'])
-            the_new_major = Major.objects.get(id=the_mess.support_data['major'])
-            the_student.major_change_approved(major=the_new_major, request_message=the_mess)
-            messages.success(request, 'Major Change Approved.')
+            elif is_admin and request.POST.get('rejectdrop', None) is not None:
+                the_mess.time_handled = datetime.now(pytz.utc)
+                the_mess.save()
+                messages.success(request, 'Trust me, you rejected the drop.')
+                return redirect('sis:messages')
 
-        elif is_admin and request.POST.get('rejectmajor', None) is not None:
-            the_mess.time_handled = datetime.now(pytz.utc)
-            the_mess.save()
-            messages.success(request, 'Trust me, you rejected the major change.')
+            elif is_admin and request.POST.get('approvemajor', None) is not None:
+                the_student = Student.objects.get(id=the_mess.support_data['student'])
+                the_new_major = Major.objects.get(id=the_mess.support_data['major'])
+                the_student.major_change_approved(major=the_new_major, request_message=the_mess)
+                messages.success(request, 'Major Change Approved.')
+                return redirect('sis:messages')
 
-        elif is_admin and request.POST.get('transcriptreq', None) is not None:
-            the_mess.time_handled = datetime.now(pytz.utc)
-            the_mess.save()
-            the_student = Student.objects.get(id=the_mess.support_data['student'])
-            response = Message.objects.create(
-                sender=the_profile,
-                recipient=the_student.profile,
-                message_type=Message.TRANSCRIPT_TYPE,
-                subject="Your Transcript",
-                body="I'll be emailing it to you.",
-                in_response_to=the_mess,
-            )
-            messages.success(request, 'Transcript promised.')
-            the_student = Student.objects.get(id=the_mess.support_data['student'])
-            # this generates and downloads the file.
-            return transcript(request, userid=the_student.profile.user.id)
+            elif is_admin and request.POST.get('rejectmajor', None) is not None:
+                the_mess.time_handled = datetime.now(pytz.utc)
+                the_mess.save()
+                messages.success(request, 'Trust me, you rejected the major change.')
+                return redirect('sis:messages')
 
-        else:
-            messages.error(request, 'Something went wrong.')
+            elif is_admin and request.POST.get('transcriptreq', None) is not None:
+                the_mess.time_handled = datetime.now(pytz.utc)
+                the_mess.save()
+                the_student = Student.objects.get(id=the_mess.support_data['student'])
+                response = Message.objects.create(
+                    sender=the_profile,
+                    recipient=the_student.profile,
+                    message_type=Message.TRANSCRIPT_TYPE,
+                    subject="Your Transcript",
+                    body="I'll be emailing it to you.",
+                    in_response_to=the_mess,
+                )
+                messages.success(request, 'Transcript promised.')
+                the_student = Student.objects.get(id=the_mess.support_data['student'])
+                # this generates and downloads the file.
+                return transcript(request, userid=the_student.profile.user.id)
 
-    # mark our received messages read. Don't touch sent messages.
-    if is_recipient and the_mess.time_read is None:
-        the_mess.time_read = datetime.now(pytz.utc)
-        the_mess.save()
+            else:
+                messages.error(request, 'Something went wrong.')
 
     handled = the_mess.time_handled is not None
     handleable_message = the_mess.message_type in (Message.DROP_REQUEST_TYPE,
@@ -142,19 +160,28 @@ def message(request, id):
     show_transcript_req = is_recipient \
         and the_mess.message_type == Message.TRANSCRIPT_REQUEST_TYPE \
         and not handled
-    return render(
-        request, 'sis/message.html', {
-            'auser': the_user,
-            'message': the_mess,
-            'show_approve_drop': show_drop,
-            'show_approve_major': show_major,
-            'show_transcript_req': show_transcript_req,
-            'show_archive': is_recipient,
-            'message_archived': the_mess.time_archived is not None,
-            'message_read': the_mess.time_read is not None,
-            'message_handled': handled,
-            'show_type': not is_student,
-            'show_handled': handleable_message and not is_student,
-            'show_read': True,
-            'can_reply': can_reply
-        })
+
+    detail_class = 'sis:viewmessage' if read_only else 'sis:message'
+    block_class = 'users' if read_only else 'messages'
+
+    data = {
+        'auser': the_user,
+        'message': the_mess,
+        'show_approve_drop': not read_only and show_drop,
+        'show_approve_major': not read_only and show_major,
+        'show_transcript_req': not read_only and show_transcript_req,
+        'show_archive': not read_only and is_recipient,
+        'message_archived': the_mess.time_archived is not None,
+        'message_read': the_mess.time_read is not None,
+        'message_handled': handled,
+        'show_type': not is_student,
+        'show_handled': handleable_message and not is_student,
+        'show_read': True,
+        'can_reply': not read_only and can_reply,
+        'detail_class': detail_class,
+        'block_class': block_class,
+    }
+
+    data.update(next_prev(request, 'received', id, fallback='sent'))
+
+    return render(request, 'sis/message.html', data)


### PR DESCRIPTION
in support of #340.

Chose to make message detail (what you see when you click on a message) a detail *page*, not a "reading view below the table". Primary reason: gives a lot more control on message actions (i.e. reply).
Secondary reason: gets rid of last iframe!!!!

Also does a much better job on viewing. On a message, present next/prev when possible. Works better for admins viewing other people's messages.

If you have time, please review. Ideally, check "your" messages (ex. hades, rexifer, <some student>), and as admin, view messages similarly (Users->rexifer, Users->lwright).

Thanks!